### PR TITLE
Add library header, address compiler warnings, and some cleanup

### DIFF
--- a/slite.el
+++ b/slite.el
@@ -74,7 +74,6 @@
    "^Unexpected Error: " ""
    (replace-regexp-in-string "\n" "" s )))
 
-
 (cl-defun slite--parse-reason (id)
   (or
    (let ((results (plist-get id :results)))
@@ -275,7 +274,6 @@
       `(slite/api::rem-test ,framework ,name ,package)
       (lambda (x) (message "Test deleted"))))))
 
-
 (define-key slite-results-mode-map (kbd "RET")
   'slite-describe-result)
 
@@ -289,7 +287,6 @@
 
 (define-key slite-results-mode-map (kbd "g")  'slite-rerun)
 
-
 (define-key slite-details-mode-map (kbd "q")
   'slite-details-quit)
 
@@ -299,8 +296,6 @@
   'slite-compile-defun-and-run-tests)
 (define-key slite-results-mode-map (kbd "C-c v")
   'slite-run)
-
-
 
 (add-hook (cl-case (slite--slime-impl)
             (:sly

--- a/slite.el
+++ b/slite.el
@@ -1,4 +1,22 @@
-;; -*- lexical-binding: t -*-
+;;; slite.el --- Interactively runs your Common Lisp tests  -*- lexical-binding: t -*-
+
+;; Copyright (C) 2021-2023 Arnold Noronha
+
+;; Author: Arnold Noronha <arnold@tdrhq.com>
+;; Homepage: https://github.com/tdrhq/slite
+;; Keywords: lisp tools
+;; Package-Requires: ((emacs "25.1"))
+;; SPDX-License-Identifier: Apache-2.0
+
+;;; Commentary:
+
+;; Slite stands for SLIme TEst runner. Slite interactively runs
+;; your Common Lisp tests (currently only FiveAM and Parachute are
+;; supported).  It allows you to see the summary of test failures,
+;; jump to test definitions, rerun tests with debugger all from
+;; inside Emacs.
+
+;;; Code:
 
 (require 'cl-lib)
 
@@ -321,3 +339,4 @@
   'slite-run)
 
 (provide 'slite)
+;;; sqlite.el ends here

--- a/slite.el
+++ b/slite.el
@@ -1,7 +1,5 @@
 ;; -*- lexical-binding: t -*-
 
-(provide 'slite)
-
 (require 'cl-lib)
 
 (define-derived-mode slite-results-mode tabulated-list-mode
@@ -321,3 +319,5 @@
 ;; forth between Lisp and elisp
 (define-key emacs-lisp-mode-map (kbd "C-c v")
   'slite-run)
+
+(provide 'slite)

--- a/slite.el
+++ b/slite.el
@@ -20,6 +20,18 @@
 
 (require 'cl-lib)
 
+(defvar slite-results-mode-map
+  (let ((map (make-sparse-keymap)))
+    (set-keymap-parent map tabulated-list-mode-map)
+    (define-key map (kbd "RET")      #'slite-describe-result)
+    (define-key map (kbd "<delete>") #'slite-delete-test)
+    (define-key map (kbd "r")        #'slite-rerun-in-debugger)
+    (define-key map (kbd "M-.")      #'slite-jump-to-test)
+    (define-key map (kbd "g")        #'slite-rerun)
+    (define-key map (kbd "C-c v")    #'slite-run)
+    map)
+  "Keymap for `slite-results-mode'.")
+
 (define-derived-mode slite-results-mode tabulated-list-mode
   "CL Test Results"
   "dfdfd"
@@ -32,6 +44,12 @@
 (defvar slite-success-shell-hook nil)
 
 (defvar slite-success-hook 'slite--on-success)
+
+(defvar slite-details-mode-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "r") #'slite-rerun-in-debugger)
+    (define-key map (kbd "q") #'slite-details-quit)
+    map))
 
 (define-derived-mode slite-details-mode fundamental-mode
   "Test Results Details"
@@ -277,28 +295,10 @@ this is incorrect, setq slite--last-command-p to nil"))
       `(slite/api::rem-test ,framework ,name ,package)
       (lambda (x) (message "Test deleted"))))))
 
-(define-key slite-results-mode-map (kbd "RET")
-  'slite-describe-result)
-
-(define-key slite-results-mode-map (kbd "<delete>")
-  'slite-delete-test)
-
-(define-key slite-results-mode-map (kbd "r") 'slite-rerun-in-debugger)
-(define-key slite-results-mode-map (kbd "M-.") 'slite-jump-to-test)
-
-(define-key slite-details-mode-map (kbd "r") 'slite-rerun-in-debugger)
-
-(define-key slite-results-mode-map (kbd "g")  'slite-rerun)
-
-(define-key slite-details-mode-map (kbd "q")
-  'slite-details-quit)
-
 (define-key lisp-mode-map (kbd "C-c v")
   'slite-run)
 (define-key lisp-mode-map (kbd "C-c j")
   'slite-compile-defun-and-run-tests)
-(define-key slite-results-mode-map (kbd "C-c v")
-  'slite-run)
 
 (add-hook (cl-case (slite--slime-impl)
             (:sly

--- a/slite.el
+++ b/slite.el
@@ -16,6 +16,17 @@
 ;; jump to test definitions, rerun tests with debugger all from
 ;; inside Emacs.
 
+;; You might want to add some key bindings in various Lisp mode maps:
+;;
+;;     (define-key emacs-lisp-mode-map (kbd "C-c v") #'slite-run)
+;;     (define-key lisp-mode-map (kbd "C-c v") #'slite-run)
+;;     (define-key lisp-mode-map (kbd "C-c j")
+;;       #'slite-compile-defun-and-run-tests)
+;;     (with-eval-after-load 'slime
+;;       (define-key slime-mode-map (kbd "C-c v") #'slite-run))
+;;     (with-eval-after-load 'sly
+;;       (define-key sly-mode-map (kbd "C-c v") #'slite-run))
+
 ;;; Code:
 
 (require 'cl-lib)
@@ -295,11 +306,6 @@ this is incorrect, setq slite--last-command-p to nil"))
       `(slite/api::rem-test ,framework ,name ,package)
       (lambda (x) (message "Test deleted"))))))
 
-(define-key lisp-mode-map (kbd "C-c v")
-  'slite-run)
-(define-key lisp-mode-map (kbd "C-c j")
-  'slite-compile-defun-and-run-tests)
-
 (add-hook (cl-case (slite--slime-impl)
             (:sly
              'sly-compilation-finished-hook)
@@ -319,22 +325,6 @@ this is incorrect, setq slite--last-command-p to nil"))
       (:sly
        (let ((sly-buffer-package package))
          (sly-edit-definition name))))))
-
-(defun slite--slime-mode-map ()
-  (cl-case (slite--slime-impl)
-    (:slime
-     slime-mode-map)
-    (:sly
-     sly-mode-map)))
-
-(define-key (slite--slime-mode-map)
-  (kbd "C-c v")
-  'slite-run)
-
-;; helpful while building slite, because I have to switch back and
-;; forth between Lisp and elisp
-(define-key emacs-lisp-mode-map (kbd "C-c v")
-  'slite-run)
 
 (provide 'slite)
 ;;; sqlite.el ends here

--- a/slite.el
+++ b/slite.el
@@ -136,14 +136,15 @@
     (with-current-buffer buffer
       (setq slite--last-expression cmd)))
   (message "Waiting for test results...")
-  (slite--sl*-eval-async `(slite::process-results (cl::eval (cl::read-from-string ,cmd)))
-                         (lambda (results)
-                           (when (and
-                                  slite-success-hook
-                                  (slite--all-tests-passed-p results))
-                             (funcall slite-success-hook))
+  (slite--sl*-eval-async
+   `(slite::process-results (cl::eval (cl::read-from-string ,cmd)))
+   (lambda (results)
+     (when (and
+            slite-success-hook
+            (slite--all-tests-passed-p results))
+       (funcall slite-success-hook))
 
-                           (slite--show-test-results results buffer))))
+     (slite--show-test-results results buffer))))
 
 (defun slite-rerun ()
   (interactive)
@@ -234,7 +235,8 @@
          (framework (plist-get id :framework))
          (name (plist-get id :test-name))
          (package (plist-get id :package)))
-    (slite--sl*-eval-async `(slite/api::rerun-in-debugger ,framework ,name ,package)
+    (slite--sl*-eval-async
+     `(slite/api::rerun-in-debugger ,framework ,name ,package)
       (lambda (x)
         (message "Result of running %s: %s" name x)))))
 
@@ -249,7 +251,8 @@
   (interactive)
   (cond
    (slite--last-command-p
-    (message "A compile-defun-and-run-tests is still running (if this is incorrect, setq slite--last-command-p to nil"))
+    (message "A compile-defun-and-run-tests is still running (if \
+this is incorrect, setq slite--last-command-p to nil"))
    (t
     (setq slite--last-command-p t)
     (setq slite--last-read-only-mode buffer-read-only)


### PR DESCRIPTION
This is a follow up to https://github.com/plandes/flex-compile/commit/c6f7b97e96b4f2608954f8f599d255578c73d600.

Please open the Melpa pull-request yourself.

/cc @plandes